### PR TITLE
Enable ipc share to improve perfomance on X11

### DIFF
--- a/de.bund.ausweisapp.ausweisapp2.yaml
+++ b/de.bund.ausweisapp.ausweisapp2.yaml
@@ -8,6 +8,7 @@ finish-args:
   - --share=network
   - --socket=wayland
   - --socket=fallback-x11
+  - --share=ipc
   - --socket=pcsc
   - --own-name=org.kde.* # Workaround for org.kde.StatusNotifierWatcher support, see https://github.com/flathub/com.viber.Viber/issues/4
   - --talk-name=org.freedesktop.Notifications


### PR DESCRIPTION
This allows to share the IPC namespace with the host, which should result in a lot better performance on X11 according to the [documentation](https://docs.flatpak.org/en/latest/sandbox-permissions-reference.html#f1):

> This is not necessarily required, but without it the X11 shared memory extension will not work, which is very bad for X11 performance.