### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/de.bund.ausweisapp.ausweisapp2.yaml
+++ b/de.bund.ausweisapp.ausweisapp2.yaml
@@ -10,7 +10,6 @@ finish-args:
   - --socket=fallback-x11
   - --share=ipc
   - --socket=pcsc
-  - --own-name=org.kde.* # Workaround for org.kde.StatusNotifierWatcher support, see https://github.com/flathub/com.viber.Viber/issues/4
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
   - --filesystem=home


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/ 66#issuecomment-1386033025