### PR TITLE
Remove home permission file system access

### DIFF
--- a/de.bund.ausweisapp.ausweisapp2.yaml
+++ b/de.bund.ausweisapp.ausweisapp2.yaml
@@ -15,7 +15,6 @@ finish-args:
   - --socket=pcsc
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
-  - --filesystem=home
 modules:
   - name: pcsc-lite
     sources:


### PR DESCRIPTION
This reverts commit e3080cadccb82e1f40310c52008b6973d3712fa2.

Fixes https://github.com/flathub/de.bund.ausweisapp.ausweisapp2/issues/31

I tested it manually with Flatseal and indeed exporting logs works. If you give it no valid file ending (ending with txt) it may end up with a random name, but I guess this is not related to anything, but just how it's implemented/qt or whatever is used works.

One time I also had it create a zip and tar.gz file, but I never saw this again (even if I granted the permission?). And even if this was expected, I guess it would only contain the log file, which is created successfully.

![image](https://github.com/flathub/de.bund.ausweisapp.ausweisapp2/assets/11966684/466cd0fa-c342-4e3a-bf97-20015e970f63)

Also the log itself confirms this works:
```
default       2023.12.07 22:08:35.977 2   Env::createSingleton(global/Env.h:127)                                     : Create singleton: governikus::ReleaseInformationConfiguration
fileprovider  2023.12.07 22:08:35.978 2   Downloader::startDownloadIfPending(file_provider/Downloader.cpp:43)        : No pending requests to be started.
default       2023.12.07 22:08:39.814 2   Env::createSingleton(global/Env.h:127)                                     : Create singleton: governikus::LogModel
feedback      2023.12.07 22:08:47.325 2 I ApplicationModel::showFeedback(ui/qml/ApplicationModel.cpp:289)            : Protokolldatei erfolgreich gespeichert unter "/run/user/1000/doc/17d78d2c/zzzzz.log"
qml           2023.12.07 22:08:47.325 2 W ApplicationModel::isScreenReaderRunning(ui/qml/ApplicationModel.cpp:254)   : NOT IMPLEMENTED
```

