### PR TITLE
Update Qt runtime to v6.6

### DIFF
--- a/de.bund.ausweisapp.ausweisapp2.yaml
+++ b/de.bund.ausweisapp.ausweisapp2.yaml
@@ -1,6 +1,6 @@
 app-id: de.bund.ausweisapp.ausweisapp2
 runtime: org.kde.Platform
-runtime-version: "6.5"
+runtime-version: "6.6"
 sdk: org.kde.Sdk
 command: AusweisApp
 rename-desktop-file: com.governikus.ausweisapp2.desktop


### PR DESCRIPTION
Makes the app run with Qt 6.6, also updates the base runtime to [freedesktop 23.08](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/releases/freedesktop-sdk-23.08.0) with all included changes.
Works like a charm:
![Bildschirmfoto vom 2023-12-10 12-48-06](https://github.com/flathub/de.bund.ausweisapp.ausweisapp2/assets/10406217/0c6194d0-5712-439b-9f73-f170a6cf86a6)
