### PR TITLE
AusweisApp: Bumping KDE runtime to 6.8

### DIFF
--- a/de.bund.ausweisapp.ausweisapp2.yaml
+++ b/de.bund.ausweisapp.ausweisapp2.yaml
@@ -1,6 +1,6 @@
 app-id: de.bund.ausweisapp.ausweisapp2
 runtime: org.kde.Platform
-runtime-version: '6.7'
+runtime-version: '6.8'
 sdk: org.kde.Sdk
 command: AusweisApp
 rename-desktop-file: com.governikus.ausweisapp2.desktop


### PR DESCRIPTION
This PR just bumps the KDE runtime to the latest release.

Hope it helps!