### PR TITLE
Update runtime to Qt 6.10

### DIFF
--- a/de.bund.ausweisapp.ausweisapp2.yaml
+++ b/de.bund.ausweisapp.ausweisapp2.yaml
@@ -1,6 +1,6 @@
 app-id: de.bund.ausweisapp.ausweisapp2
 runtime: org.kde.Platform
-runtime-version: '6.9'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 command: AusweisApp
 rename-desktop-file: com.governikus.ausweisapp2.desktop


### PR DESCRIPTION
Works fine without issues on my side, of course testing from your side would be appreciated as well. Updates the underlying Freedesktop runtime from 24.08 to 25.08 as well.
See here for more infos:
https://discourse.flathub.org/t/freedesktop-sdk-25-08-0-released/10399
https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/freedesktop-sdk-25.08.0/NEWS.yml

<img width="1296" height="1009" alt="Bildschirmfoto_20251126_110314" src="https://github.com/user-attachments/assets/fcc51442-4da8-45e4-a4a4-263b47a65c38" />
